### PR TITLE
change apk add python to python3

### DIFF
--- a/wallpad/Dockerfile
+++ b/wallpad/Dockerfile
@@ -9,7 +9,7 @@ COPY run.sh /
 COPY js /js
 
 # Install requirements for add-on
-RUN apk add --no-cache jq npm make gcc g++ python linux-headers udev && \
+RUN apk add --no-cache jq npm make gcc g++ python3 linux-headers udev && \
     npm init -f && \
     npm install mqtt && \
     npm install serialport --build-from-source=serialport 


### PR DESCRIPTION
apline linux 최신 Docker 이미지에서 더이상 python  패키지를 지원하지 않아서 설치 오류가 납니다. python3 로 변경해야 합니다.

의도된 변경으로 보입니다.
https://9to5linux.com/alpine-linux-3-12-released-with-initial-mips64-port-support-for-yubikeys
*"the py3-setuptools package now uses system-wide python3 modules instead of the vendor dependencies, python2 no longer provides python and python-devel, and python3 no longer provides pip3 as users are urged to use py3-pip instead."*